### PR TITLE
Add custom module name

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,6 +20,7 @@ android {
     // For Kotlin projects
     kotlinOptions {
         jvmTarget = "1.8"
+        kotlinOptions.freeCompilerArgs += ['-module-name', "com.github.kirich1409.ViewBindingPropertyDelegate"]
     }
 
 


### PR DESCRIPTION
Fixes error
```
Execution failed for task ':app:mergeDebugJavaResource'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > More than one file was found with OS independent path 'META-INF/library_release.kotlin_module'.
```

AS helped me to find libraries
<img width="505" alt="scr" src="https://user-images.githubusercontent.com/1156370/85331261-df4c0380-b4e6-11ea-8aeb-9daac34881ff.png">

According to [this](https://blog.jetbrains.com/kotlin/2015/09/kotlin-m13-is-out/) page, the library should specify a module name
> We had to introduce a new resource file that is required to compile Kotlin code against Kotlin binaries. Its name is META-INF/<module_name>.kotlin_module. Make sure these .kotlin_module files are not stripped by your packaging process. Also, make sure that module names do not clash in your project.
