### PR TITLE
build(gradle): Support API 16

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,7 +7,7 @@ android {
 
     defaultConfig {
         applicationId "by.kirich1409.viewbindingdelegate.profile"
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ android {
     buildToolsVersion "30.0.3"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 16
         targetSdkVersion 29
 
         consumerProguardFiles 'proguard-rules.pro'


### PR DESCRIPTION
Unfortunately, our apps still needs support for min SDK 16, is there any concern using min SDK 21 in this great library :)? 

Otherwise it will be great if you accept this PR or if there's a room for improvements, please notes at here as well

@kirich1409 @DeKaN 