### PR TITLE
Better way to associate ViewBinding with Fragment without reflection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ dependencies {
 class ProfileFragment : Fragment(R.layout.profile) {
 
     private val viewBinding: ProfileBinding by viewBinding()
+
+    private val viewBindingWithoutReflection by viewBinding(ProfileBinding::bind)
 }
 ```
 

--- a/app/src/main/java/by/kirich1409/viewbindingdelegate/sample/ProfileFragment1.kt
+++ b/app/src/main/java/by/kirich1409/viewbindingdelegate/sample/ProfileFragment1.kt
@@ -6,11 +6,13 @@ import androidx.fragment.app.Fragment
 import by.kirich1409.viewbindingdelegate.sample.databinding.ProfileBinding
 import by.kirich1409.viewbindingdelegate.viewBinding
 
-class ProfileFragment : Fragment(R.layout.profile) {
+class ProfileFragment1 : Fragment(R.layout.profile) {
 
     private val viewBindingUsingReflection: ProfileBinding by viewBinding()
 
-    private val viewBindingWithoutReflection by viewBinding { fragment ->
+    private val viewBindingWithoutReflection1 by viewBinding { fragment ->
         ProfileBinding.bind(fragment.requireView())
     }
+
+    private val viewBindingWithoutReflection2 by viewBinding(ProfileBinding::bind)
 }

--- a/app/src/main/java/by/kirich1409/viewbindingdelegate/sample/ProfileFragment2.kt
+++ b/app/src/main/java/by/kirich1409/viewbindingdelegate/sample/ProfileFragment2.kt
@@ -1,0 +1,38 @@
+@file:Suppress("unused")
+
+package by.kirich1409.viewbindingdelegate.sample
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.fragment.app.Fragment
+import by.kirich1409.viewbindingdelegate.sample.databinding.ProfileBinding
+import by.kirich1409.viewbindingdelegate.viewBinding
+
+class ProfileFragment2 : ComplexFragment(R.layout.profile) {
+
+    private val viewBinding by viewBinding(ProfileBinding::bind, ComplexFragment::requireInternalView)
+}
+
+abstract class ComplexFragment(
+    @LayoutRes private val internalLayoutId: Int
+): Fragment() {
+    
+    private var internalView: View? = null
+    
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val complexView = inflater.inflate(R.layout.complex, container, false) as ViewGroup
+        internalView = inflater.inflate(internalLayoutId, complexView, false)
+        complexView.findViewById<ViewGroup>(R.id.container)?.addView(internalView)
+        return complexView
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        internalView = null
+    }
+
+    fun requireInternalView(): View = internalView ?: throw IllegalStateException("internalView is null")
+}

--- a/app/src/main/res/layout/complex.xml
+++ b/app/src/main/res/layout/complex.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:viewBindingIgnore="true">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="16dip"
+        android:textAppearance="?android:textAppearanceMedium"
+        tools:text="Title" />
+
+</LinearLayout>

--- a/library/src/main/java/by/kirich1409/viewbindingdelegate/ViewBindingProperty.kt
+++ b/library/src/main/java/by/kirich1409/viewbindingdelegate/ViewBindingProperty.kt
@@ -14,6 +14,7 @@ import androidx.viewbinding.ViewBinding
 import by.kirich1409.viewbindingdelegate.internal.ActivityViewBinder
 import by.kirich1409.viewbindingdelegate.internal.DialogFragmentViewBinder
 import by.kirich1409.viewbindingdelegate.internal.FragmentViewBinder
+import by.kirich1409.viewbindingdelegate.internal.ReflectingFragmentViewBinder
 import by.kirich1409.viewbindingdelegate.internal.checkIsMainThread
 import by.kirich1409.viewbindingdelegate.internal.requireViewByIdCompat
 import kotlin.properties.ReadOnlyProperty
@@ -107,7 +108,16 @@ fun <A : ComponentActivity, T : ViewBinding> A.viewBinding(viewBinder: (A) -> T)
 @Suppress("unused")
 @JvmName("viewBindingFragment")
 inline fun <F : Fragment, reified T : ViewBinding> F.viewBinding(): ViewBindingProperty<Fragment, T> {
-    return viewBinding(FragmentViewBinder(T::class.java)::bind)
+    return viewBinding(ReflectingFragmentViewBinder(T::class.java)::bind)
+}
+
+/**
+ * Create new [ViewBinding] associated with the [Fragment][this]
+ */
+@Suppress("unused")
+@JvmName("viewBindingFragment")
+fun <F : Fragment, T : ViewBinding> F.viewBinding(viewBinder: (View) -> T, viewFinder: (F) -> View = Fragment::requireView): ViewBindingProperty<F, T> {
+    return viewBinding(FragmentViewBinder(viewBinder, viewFinder)::bind)
 }
 
 /**

--- a/library/src/main/java/by/kirich1409/viewbindingdelegate/internal/FragmentViewBinder.kt
+++ b/library/src/main/java/by/kirich1409/viewbindingdelegate/internal/FragmentViewBinder.kt
@@ -4,10 +4,11 @@ import android.view.View
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
 import androidx.viewbinding.ViewBinding
+import by.kirich1409.viewbindingdelegate.viewBinding
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 @PublishedApi
-internal class FragmentViewBinder<T : ViewBinding>(private val viewBindingClass: Class<T>) {
+internal class ReflectingFragmentViewBinder<T : ViewBinding>(private val viewBindingClass: Class<T>) {
 
     /**
      * Cache static method `ViewBinding.bind(View)`
@@ -22,5 +23,21 @@ internal class FragmentViewBinder<T : ViewBinding>(private val viewBindingClass:
     @Suppress("UNCHECKED_CAST")
     fun bind(fragment: Fragment): T {
         return bindViewMethod(null, fragment.requireView()) as T
+    }
+}
+
+
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+@PublishedApi
+internal class FragmentViewBinder<F: Fragment, T : ViewBinding>(
+    private val viewBinder: (View) -> T,
+    private val viewFinder: (F) -> View
+) {
+
+    /**
+     * Create new [ViewBinding] instance
+     */
+    fun bind(fragment: F): T {
+        return viewBinder(viewFinder(fragment))
     }
 }


### PR DESCRIPTION
I'm using very similar way to associate ViewBinding with Fragment but have slightly  different way to do that without reflection.

This PR adds same possibilities to ViewBindingPropertyDelegate:
```kotlin
class ProfileFragment : Fragment(R.layout.profile) {
    private val viewBinding by viewBinding(ProfileBinding::bind)
}
```

It also contains a possibility to bind not only on root fragment view (see ProfileFragment2.kt):
```kotlin
class ProfileFragment : ComplexFragment(R.layout.profile) {
    private val viewBinding by viewBinding(ProfileBinding::bind, ComplexFragment::requireInternalView)
}
```