### PR TITLE
Fix missed storing thisRef of fragment

### DIFF
--- a/library/src/main/java/by/kirich1409/viewbindingdelegate/ViewBindingProperty.kt
+++ b/library/src/main/java/by/kirich1409/viewbindingdelegate/ViewBindingProperty.kt
@@ -24,13 +24,14 @@ public abstract class ViewBindingProperty<in R : Any, T : ViewBinding>(
 
     @MainThread
     public override fun getValue(thisRef: R, property: KProperty<*>): T {
-        check(thisRef !== this.thisRef) {
+        check(this.thisRef?.equals(thisRef) ?: true) {
             "Instance of ViewBindingProperty can't be shared between different properties"
         }
 
         checkIsMainThread()
         viewBinding?.let { return it }
 
+        this.thisRef = thisRef
         getLifecycleOwner(thisRef).lifecycle.addObserver(lifecycleObserver)
         return viewBinder(thisRef).also { viewBinding = it }
     }


### PR DESCRIPTION
Fix storing thisRef of the fragment for a case of cleaning the viewBinding object
 - Add missed save of thisRef
 - Fix check on Fragment reference
Case: add a fragment to backstack and get it back. The fragment will create a new view but viewBinding is not updated