### PR TITLE
Remove unnecessary lifecycle unsubscription

### DIFF
--- a/vbpd/vbpd-noreflection/src/main/java/by/kirich1409/viewbindingdelegate/ViewBindingProperty.kt
+++ b/vbpd/vbpd-noreflection/src/main/java/by/kirich1409/viewbindingdelegate/ViewBindingProperty.kt
@@ -47,7 +47,6 @@ public abstract class LifecycleViewBindingProperty<in R : Any, T : ViewBinding>(
 ) : ViewBindingProperty<R, T> {
 
     private var viewBinding: T? = null
-    private var thisRef: R? = null
 
     protected abstract fun getLifecycleOwner(thisRef: R): LifecycleOwner
 
@@ -55,7 +54,6 @@ public abstract class LifecycleViewBindingProperty<in R : Any, T : ViewBinding>(
     public override fun getValue(thisRef: R, property: KProperty<*>): T {
         viewBinding?.let { return it }
 
-        this.thisRef = thisRef
         val lifecycle = getLifecycleOwner(thisRef).lifecycle
         val viewBinding = viewBinder(thisRef)
         if (lifecycle.currentState == Lifecycle.State.DESTROYED) {
@@ -69,8 +67,6 @@ public abstract class LifecycleViewBindingProperty<in R : Any, T : ViewBinding>(
 
     @MainThread
     public override fun clear() {
-        thisRef ?: return
-        thisRef = null
         mainHandler.post { viewBinding = null }
     }
 

--- a/vbpd/vbpd-noreflection/src/main/java/by/kirich1409/viewbindingdelegate/ViewBindingProperty.kt
+++ b/vbpd/vbpd-noreflection/src/main/java/by/kirich1409/viewbindingdelegate/ViewBindingProperty.kt
@@ -47,7 +47,6 @@ public abstract class LifecycleViewBindingProperty<in R : Any, T : ViewBinding>(
 ) : ViewBindingProperty<R, T> {
 
     private var viewBinding: T? = null
-    private val lifecycleObserver = ClearOnDestroyLifecycleObserver()
     private var thisRef: R? = null
 
     protected abstract fun getLifecycleOwner(thisRef: R): LifecycleOwner
@@ -62,7 +61,7 @@ public abstract class LifecycleViewBindingProperty<in R : Any, T : ViewBinding>(
         if (lifecycle.currentState == Lifecycle.State.DESTROYED) {
             // We can access to ViewBinding after on destroy, but don't save to prevent memory leak
         } else {
-            lifecycle.addObserver(lifecycleObserver)
+            lifecycle.addObserver(ClearOnDestroyLifecycleObserver())
             this.viewBinding = viewBinding
         }
         return viewBinding
@@ -70,9 +69,8 @@ public abstract class LifecycleViewBindingProperty<in R : Any, T : ViewBinding>(
 
     @MainThread
     public override fun clear() {
-        val thisRef = thisRef ?: return
-        this.thisRef = null
-        getLifecycleOwner(thisRef).lifecycle.removeObserver(lifecycleObserver)
+        thisRef ?: return
+        thisRef = null
         mainHandler.post { viewBinding = null }
     }
 


### PR DESCRIPTION
No need to remove lifecycle listeners. All listeners will be deleted automatically by on_destroy event