### PR TITLE
Revert Proguard rules

### DIFF
--- a/vbpd/vbpd-full/proguard-rules.pro
+++ b/vbpd/vbpd-full/proguard-rules.pro
@@ -1,4 +1,4 @@
--keep,allowoptimization,allowshrinking class * implements androidx.viewbinding.ViewBinding {
+-keep class * implements androidx.viewbinding.ViewBinding {
     public static *** bind(android.view.View);
     public static *** inflate(...);
 }


### PR DESCRIPTION
This commit made our app crash when running a release variant: 
https://github.com/kirich1409/ViewBindingPropertyDelegate/commit/907b13b5c1a18be4a988166d0393737880c43e28#diff-be7704ec9038c559b1f99dfc3600299d5cad056d32f60028f1d037bc6ed2475f

This issue was reported by my colleague Cristan: 
https://github.com/kirich1409/ViewBindingPropertyDelegate/issues/49

Reverting the rules made it work again.